### PR TITLE
Create if not exists index

### DIFF
--- a/lib/ecto_adapters_dynamodb/migration.ex
+++ b/lib/ecto_adapters_dynamodb/migration.ex
@@ -468,10 +468,8 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
           end)
       end
 
-    case filtered_attribute_definitions do
-      nil -> %{global_secondary_index_updates: filtered_global_secondary_index_updates}
-      _ -> %{attribute_definitions: filtered_attribute_definitions, global_secondary_index_updates: filtered_global_secondary_index_updates}
-    end
+    %{global_secondary_index_updates: filtered_global_secondary_index_updates}
+    |> Map.merge(if is_nil(filtered_attribute_definitions), do: %{}, else: %{attribute_definitions: filtered_attribute_definitions})
   end
 
   defp list_existing_global_secondary_index_names(table_name) do

--- a/lib/ecto_adapters_dynamodb/migration.ex
+++ b/lib/ecto_adapters_dynamodb/migration.ex
@@ -263,11 +263,12 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
 
     else
 
-      # IF THE VALUE OF create IN THE ALTER FUNCTION WAS AN EMPTY LIST, data WILL BE MISSING :attribute_definitions
-      # THIS WILL OCCUR WHEN EITHER NO SECONDARY GLOBALS WERE ADDED, OR ALL THAT WERE ADDED ALREADY EXIST
-      case data[:attribute_definitions] do
-        nil -> nil
+      # IF THE VALUE OF create IN THE ALTER FUNCTION WAS AN EMPTY LIST, :global_secondary_index_updates WILL
+      # BE EMPTY, TOO. SKIP THE WHOLE THING, THERE'S NOTHING TO DO.
+      case data[:global_secondary_index_updates] do
+        [] -> nil
         _ ->
+
           result = Dynamo.update_table(table_name, data) |> ExAws.request
 
           ecto_dynamo_log(:info, "#{inspect __MODULE__}.update_table_recursive: DynamoDB/ExAws response", %{"#{inspect __MODULE__}.update_table_recursive-result" => inspect result})

--- a/lib/ecto_adapters_dynamodb/migration.ex
+++ b/lib/ecto_adapters_dynamodb/migration.ex
@@ -442,7 +442,9 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
   defp list_existing_global_secondary_index_names(table) do
     case poll_table(table.name)["GlobalSecondaryIndexes"] do
       nil -> []
-      existing_indexes -> Enum.map(existing_indexes, fn(existing_index) -> existing_index["IndexName"] end)
+      existing_indexes ->
+        Enum.filter(existing_indexes, fn(existing_index) -> existing_index["IndexStatus"] != "DELETING" end)
+        |> Enum.map(fn(existing_index) -> existing_index["IndexName"] end)
     end
   end
 

--- a/lib/ecto_adapters_dynamodb/migration.ex
+++ b/lib/ecto_adapters_dynamodb/migration.ex
@@ -8,7 +8,7 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
   
   The functions, `add`, `remove` and `modify` correspond to indexes on the DynamoDB table. Using `add`, the second parameter, field type (which corresponds with the DynamoDB attribute) must be specified. Use the third parameter to specify a primary key not already specified. For a HASH-only primary key, use `primary_key: true` as the third parameter. For a composite primary key (HASH and RANGE), in addition to the `primary_key` specification, set the third parameter on the range key attribute to `range_key: true`. There should be only one primary key (hash or composite) specified per table.
  
-  To specify index details, such as provisioned throughput, global and local indexes, use the `options` keyword in `create table` and `alter table`, please see the examples below for greater detail.
+  To specify index details, such as provisioned throughput, create_if_not_exists/drop_if_exists, global and local indexes, use the `options` keyword in `create table` and `alter table`, please see the examples below for greater detail.
 
   *Please note that `change` may not work as expected on rollback. We recommend specifying `up` and `down` instead.*
 
@@ -46,6 +46,7 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
           global_indexes: [
             [index_name: "content",
              keys: [:content],
+             create_if_not_exists: true,
              projection: [projection_type: :include, non_key_attributes: [:email]]]
           ]
         ]) do
@@ -55,7 +56,13 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
     end
 
     def down do
-      alter table(:post) do
+      alter table(:post,
+        options: [
+          global_indexes: [
+            [index_name: "content",
+              drop_if_exists: true]]
+        ]
+      ) do
         remove :content
       end
     end


### PR DESCRIPTION
Added changes that allow for the use of `:create_if_not_exists` and` :drop_if_exists` table options for indexes during migrations.