### PR TITLE
Set state to :loaded when data is persisted in database

### DIFF
--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -1084,6 +1084,7 @@ defmodule Ecto.Adapters.DynamoDB do
 
     %{"Item" => item}
     |> Dynamo.decode_item(as: model)
+    |> Ecto.put_meta(state: :loaded)
     |> custom_decode(model, select)
   end
 

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -84,6 +84,7 @@ defmodule Ecto.Adapters.DynamoDB.Test do
 
       assert result.first_name == "John"
       assert result.last_name == "Lennon"
+      assert Ecto.get_meta(result, :state) == :loaded
     end
 
     test "insert a record and get with a hash/range pkey" do
@@ -106,8 +107,8 @@ defmodule Ecto.Adapters.DynamoDB.Test do
                                                text: "ghi",
                                              })
 
-      {:ok, _} = TestRepo.insert(cs1)
-      {:ok, _} = TestRepo.insert(cs2)
+      {:ok, page1} = TestRepo.insert(cs1)
+      {:ok, page2} = TestRepo.insert(cs2)
       {:error, _} = TestRepo.insert(duplicate_page_cs)
 
       query = from p in BookPage, where: p.id == ^name


### PR DESCRIPTION
Ecto provides the `state` [metadata](https://hexdocs.pm/ecto/Ecto.Schema.Metadata.html#module-state) to identify if a record is persisted in the database (`:loaded`) or simply a new record in memory and not yet persisted (`:built`). 

This PR ensures the `state` is set to `:loaded` when a record is retrieved from the database. 