### PR TITLE
Support for schemas with composite primary keys

### DIFF
--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -142,7 +142,7 @@ defmodule Ecto.Adapters.DynamoDB do
   def prepare(:all, query) do
     # 'preparing' is more a SQL concept - Do we really need to do anything here or just pass the params through?
     ecto_dynamo_log(:debug, "#{inspect __MODULE__}.prepare: :all", %{"#{inspect __MODULE__}.prepare-params" => %{query: inspect(query, structs: false)}})
- 
+
     {:nocache, {:all, query}}
   end
 
@@ -580,7 +580,7 @@ defmodule Ecto.Adapters.DynamoDB do
                                  end)
 
     result_body_for_log = %{table => Enum.flat_map(results, fn(res) -> res[unprocessed_items_element][table] || [] end)}
-    
+
     ecto_dynamo_log(:info, "#{inspect __MODULE__}.batch_write: batch_write_attempt result", %{"#{inspect __MODULE__}.insert_all-batch_write" => inspect %{unprocessed_items_element => (if result_body_for_log[table] == [], do: %{}, else: result_body_for_log)}})
 
     {total_processed, nil}
@@ -623,44 +623,13 @@ defmodule Ecto.Adapters.DynamoDB do
   end
 
 
-  # In testing, 'filters' contained only the primary key and value
-  # TODO: handle cases of more than one tuple in 'filters'?
   def delete(repo, schema_meta, filters, opts) do
     ecto_dynamo_log(:debug, "#{inspect __MODULE__}.delete", %{"#{inspect __MODULE__}.delete-params" => %{repo: repo, schema_meta: schema_meta, filters: filters, opts: opts}})
 
     {_, table} = schema_meta.source
 
-    # We offer the :range_key option for tables with composite primary key
-    # since Ecto will not provide the range_key value needed for the query.
-    # If :range_key is not provided, check if the table has a composite
-    # primary key and query for all the key values
-    updated_filters = case opts[:range_key] do
-      nil ->
-        {:primary, key_list} = Ecto.Adapters.DynamoDB.Info.primary_key!(table)
-        if (length key_list) > 1 do
-          updated_opts = opts ++ [projection_expression: Enum.join(key_list, ", ")]
-          filters_as_strings = for {field, val} <- filters, do: {Atom.to_string(field), {val, :==}}
-          fetch_result = Ecto.Adapters.DynamoDB.Query.get_item(table, filters_as_strings, updated_opts)
-          items = case fetch_result do
-            %{"Items" => fetch_items} -> fetch_items
-            %{"Item" => item}         -> [item]
-            _                         -> []
-          end
-
-          if items == [], do: raise "#{inspect __MODULE__}.delete error: no results found for record: #{inspect filters}"
-          if (length items) > 1, do: raise "#{inspect __MODULE__}.delete error: more than one result found for record: #{inspect filters} Please consider using the adapter's :range_key custom inline option (see README)."
-
-          for {field, key_map} <- Map.to_list(hd items) do
-            [{_field_type, val}] = Map.to_list(key_map)
-            {field, val}
-          end
-         else
-          filters
-         end
-
-      range_key ->
-        [range_key | filters]
-    end
+    updated_filters =
+      maybe_update_filters_for_range_key(table, schema_meta, filters, opts, "delete")
 
     attribute_names = construct_expression_attribute_names(keys_to_atoms(filters))
 
@@ -683,37 +652,7 @@ defmodule Ecto.Adapters.DynamoDB do
 
     {_, table} = schema_meta.source
 
-    # We offer the :range_key option for tables with composite primary key
-    # since Ecto will not provide the range_key value needed for the query.
-    # If :range_key is not provided, check if the table has a composite
-    # primary key and query for all the key values
-    updated_filters = case opts[:range_key] do
-      nil ->
-        {:primary, key_list} = Ecto.Adapters.DynamoDB.Info.primary_key!(table)
-        if (length key_list) > 1 do
-          updated_opts = opts ++ [projection_expression: Enum.join(key_list, ", ")]
-          filters_as_strings = for {field, val} <- filters, do: {Atom.to_string(field), {val, :==}}
-          fetch_result = Ecto.Adapters.DynamoDB.Query.get_item(table, filters_as_strings, updated_opts)
-          items = case fetch_result do
-            %{"Items" => fetch_items} -> fetch_items
-            %{"Item" => item}         -> [item]
-            _                         -> []
-          end
-
-          if items == [], do: raise "#{inspect __MODULE__}.update error: no results found for record: #{inspect filters}"
-          if (length items) > 1, do: raise "#{inspect __MODULE__}.update error: more than one result found for record: #{inspect filters} Please consider using the adapter's :range_key custom inline option (see README)."
-
-          for {field, key_map} <- Map.to_list(hd items) do
-            [{_field_type, val}] = Map.to_list(key_map)
-            {field, val}
-          end
-         else
-          filters
-         end
-
-      range_key ->
-        [range_key | filters]
-    end
+    updated_filters = maybe_update_filters_for_range_key(table, schema_meta, filters, opts, "update")
 
     update_expression = construct_update_expression(fields, opts)
     # add updated_filters to attribute_ names and values for condition_expression
@@ -735,14 +674,60 @@ defmodule Ecto.Adapters.DynamoDB do
     end
   end
 
+
+
+  # Support for tables with a hash+range key.
+  #
+  #  * If the schema has both keys declared (using the `primary_key: true`) the filters are already correct
+  #  * If :range_key is specified with a value it is added to filters
+  #  * If :range_key is not specified, and the table does have a range key, attempt to find it with a DynamoDB query
+  #
+  defp maybe_update_filters_for_range_key(table, schema_meta, filters, opts, action) do
+      with primary_key_length <- length(schema_meta.schema.__schema__(:primary_key)) do
+        case opts[:range_key] do
+          # Use primary keys declared in schema
+          nil when primary_key_length == 2 ->
+            filters
+          nil ->
+            {:primary, key_list} = Ecto.Adapters.DynamoDB.Info.primary_key!(table)
+            if (length key_list) > 1 do
+              updated_opts = opts ++ [projection_expression: Enum.join(key_list, ", ")]
+              filters_as_strings = for {field, val} <- filters, do: {Atom.to_string(field), {val, :==}}
+              fetch_result = Ecto.Adapters.DynamoDB.Query.get_item(table, filters_as_strings, updated_opts)
+              items = case fetch_result do
+                %{"Items" => fetch_items} -> fetch_items
+                %{"Item" => item}         -> [item]
+                _                         -> []
+              end
+
+              if items == [], do: raise "#{inspect __MODULE__}.#{action} error: no results found for record: #{inspect filters}"
+              if (length items) > 1, do: raise "#{inspect __MODULE__}.#{action} error: more than one result found for record: #{inspect filters} Please consider using the adapter's :range_key custom inline option (see README)."
+
+              for {field, key_map} <- Map.to_list(hd items) do
+                [{_field_type, val}] = Map.to_list(key_map)
+                {field, val}
+              end
+            else
+              filters
+            end
+
+          range_key ->
+            [range_key | filters]
+        end
+      end
+  end
+
   defp keys_to_atoms(list),
   do: for {k, v} <- list, do: {maybe_string_to_atom(k), v}
 
   defp maybe_string_to_atom(s),
   do: if is_binary(s), do: String.to_atom(s), else: s
 
-  defp construct_condition_expression([{field, _val}] = _filters),
-  do: "attribute_exists(##{to_string(field)})"
+  defp construct_condition_expression(filters) when is_list(filters) do
+    Keyword.keys(filters)
+    |> Enum.map(fn field -> "attribute_exists(##{to_string(field)})" end)
+    |> Enum.join(" AND ")
+  end
 
   defp extract_query_info(result), do: result |> Map.take(["Count", "ScannedCount", "LastEvaluatedKey", "UnprocessedItems", "UnprocessedKeys"])
 

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -656,6 +656,41 @@ defmodule Ecto.Adapters.DynamoDB.Test do
     end
   end
 
+  describe "modifying records with composite primary keys" do
+    test "update a record using a hash and range key" do
+      assert {:ok, book_page} = TestRepo.insert(%BookPage{
+        id: "gatsby",
+        page_num: 1
+      })
+
+      {:ok, _} = BookPage.changeset(book_page, %{text: "Believe"})
+      |> TestRepo.update()
+
+      assert %BookPage{text: "Believe"}  = TestRepo.get_by(BookPage, [id: "gatsby", page_num: 1])
+
+      {:ok, _} = TestRepo.delete(book_page)
+
+      assert nil == TestRepo.get_by(BookPage, [id: "gatsby", page_num: 1])
+    end
+
+    test "update a record using the legacy :range_key option" do
+      assert 1 == length(Planet.__schema__(:primary_key)), "the schema have a single key declared"
+
+      assert {:ok, planet} = TestRepo.insert(%Planet{
+        id: "neptune",
+        name: "Neptune",
+        mass: 123245
+      })
+
+      {:ok, updated_planet} =
+        Ecto.Changeset.change(planet, mass: 0)
+        |> TestRepo.update(range_key: {:name, planet.name})
+
+      {:ok, _} =
+        TestRepo.delete(%Planet{id: planet.id}, range_key: {:name, planet.name})
+    end
+  end
+
 
   # Batch insert a list of records into the Person model.
   defp handle_batch_insert_person(people_to_insert) when is_list people_to_insert do

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -74,7 +74,7 @@ defmodule Ecto.Adapters.DynamoDB.TestSchema.Person do
   use Ecto.Schema
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
-  
+
   alias Ecto.Adapters.DynamoDB.TestSchema.Address
 
   schema "test_person" do
@@ -99,17 +99,15 @@ defmodule Ecto.Adapters.DynamoDB.TestSchema.Person do
   end
 end
 
-# This is used to test records that have a hash+range primary key
-# However there's no way to specify this on the Ecto side: we just
-# tell Ecto that the hash key (:id) is the primary key, and that the
-# range key (:page_num) is a required field.
+# This is used to test records that have a hash+range primary key.
+# Use the `primary_key: true` option on the field for the range key.
 defmodule Ecto.Adapters.DynamoDB.TestSchema.BookPage do
   use Ecto.Schema
   @primary_key {:id, :binary_id, autogenerate: true}
   @foreign_key_type :binary_id
 
   schema "test_book_page" do
-    field :page_num, :integer
+    field :page_num, :integer, primary_key: true
     field :text,     :string
   end
 


### PR DESCRIPTION
Fixes #10 

Adds support for the range key to be declared in the Ecto schema with `primary_key: true`. 

Schemas with composite primary keys do not require the `:range_key` option when performing updates or deletes. The `:range_key` option is still supported but I would be inclined to deprecate it.

I have included some minor refactoring. Please let me know if you have any feedback!
