### PR TITLE
47

### DIFF
--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -7,11 +7,6 @@ defmodule Ecto.Adapters.DynamoDB do
   @behaviour Ecto.Adapter.Queryable
   @behaviour Ecto.Adapter.Migration
 
-  @impl Ecto.Adapter
-  defmacro __before_compile__(_env) do
-    # Nothing to see here, yet...
-  end
-
   use Bitwise, only_operators: true
 
   alias ExAws.Dynamo
@@ -22,6 +17,11 @@ defmodule Ecto.Adapters.DynamoDB do
   # DynamoDB will reject attempts to batch write more than 25 records at once
   # https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_BatchWriteItem.html
   @batch_write_item_limit 25
+
+  @impl Ecto.Adapter
+  defmacro __before_compile__(_env) do
+    # Nothing to see here, yet...
+  end
 
   def start_link({_module, config}) do
     ecto_dynamo_log(:debug, "#{inspect __MODULE__}.start_link", %{"#{inspect __MODULE__}.start_link-params" => %{config: config}})

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -382,6 +382,10 @@ defmodule Ecto.Adapters.DynamoDB.Test do
                select: p.id)
              |> TestRepo.all()
              |> Enum.sort() == sorted_ids
+      assert from(p in Person,
+               where: p.id in ^ids
+                 and is_nil(p.age))
+             |> TestRepo.all() == []
     end
 
     test "'all... in...' query, hard-coded and a variable lists of composite primary keys" do
@@ -487,6 +491,7 @@ defmodule Ecto.Adapters.DynamoDB.Test do
         query
         |> TestRepo.all(index: "age_first_nam")
       end
+
       assert query
              |> TestRepo.all(index: "age_first_name")
              |> length() == 2


### PR DESCRIPTION
@franko-franicevich  @alhambra1 @bernardd This PR has my proposed fix for issue #47 - in a nutshell, if an `in` query's parameters are exclusive to the primary key field (or fields, in the case of a composite key), then Dynamo's `BatchGetItem` will be called.  For example:

```
from(p in Person, where: p.id in ^ids)
```

or

```
from(bp in BookPage,
   where: bp.id in ^ids
     and bp.page_num in ^pages)
```

However, if the query's parameters include fields that are not exclusive to the primary key's fields, then a filter condition is present and a Dynamo query will be used instead. For example:

```
from(p in Person,
  where: p.id in ^ids
    and is_nil(p.age))
```

I'm curious about your thoughts on my use of anonymous functions within the call to `Query.get_item/3` for `do_fetch_recursive` and `do_in_query`. Any reasons that doesn't seem like a good idea? It'd be easy enough to move them out into private methods if that seemed like a better approach.

Thanks!