### PR TITLE
Fix BillingModeSummary issue that affected migrations

### DIFF
--- a/lib/ecto_adapters_dynamodb/migration.ex
+++ b/lib/ecto_adapters_dynamodb/migration.ex
@@ -331,7 +331,7 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
   # that attempt to add an index to a provisioned table without specifying throughput. The problem doesn't exist
   # the other way around; local Dynamo will ignore throughput specified for indexes where the table is on-demand.
   defp maybe_default_throughput_local(_using_ddb_local, data, table_info) do
-    if table_info["BillingModeSummary"]["BillingMode"] == "PROVISIONED" do
+    if not Map.has_key?(table_info, "BillingModeSummary") or table_info["BillingModeSummary"]["BillingMode"] == "PROVISIONED" do
       updated_global_secondary_index_updates =
         for index_update <- data.global_secondary_index_updates, {action, index_info} <- index_update do
           if action in [:create, :update] do

--- a/test/ecto_adapters_dynamodb/info_test.exs
+++ b/test/ecto_adapters_dynamodb/info_test.exs
@@ -14,10 +14,6 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
         %{"AttributeName" => "mass", "AttributeType" => "N"},
         %{"AttributeName" => "name", "AttributeType" => "S"}
       ],
-      "BillingModeSummary" => %{
-        "BillingMode" => "PROVISIONED",
-        "LastUpdateToPayPerRequestDateTime" => 0.0
-      },
      "GlobalSecondaryIndexes" => [
         %{
           "IndexArn" => "arn:aws:dynamodb:ddblocal:000000000000:table/test_planet/index/name_mass",

--- a/test/ecto_adapters_dynamodb/migration_test.exs
+++ b/test/ecto_adapters_dynamodb/migration_test.exs
@@ -38,7 +38,6 @@ defmodule Ecto.Adapters.DynamoDB.Migration.Test do
 
     test "create: provisioned table" do
       result = Ecto.Migrator.run(TestRepo, @migration_path, :up, step: 1)
-      table_info = Ecto.Adapters.DynamoDB.Info.table_info("cat")
 
       assert length(result) == 1
     end

--- a/test/ecto_adapters_dynamodb/migration_test.exs
+++ b/test/ecto_adapters_dynamodb/migration_test.exs
@@ -41,7 +41,6 @@ defmodule Ecto.Adapters.DynamoDB.Migration.Test do
       table_info = Ecto.Adapters.DynamoDB.Info.table_info("cat")
 
       assert length(result) == 1
-      assert table_info["BillingModeSummary"]["BillingMode"] == "PROVISIONED"
     end
 
     test "alter table: add index to on-demand table" do

--- a/test/integration/ex_aws_dynamo_test.exs
+++ b/test/integration/ex_aws_dynamo_test.exs
@@ -14,7 +14,6 @@ defmodule Ecto.Adapters.DynamoDB.Integration.ExAws.Dynamo.Test do
     {:ok, table_info} = ExAws.Dynamo.describe_table(@ex_aws_dynamo_test_table_name) |> ExAws.request()
 
     assert table_info["Table"]["TableName"] == @ex_aws_dynamo_test_table_name
-    assert table_info["Table"]["BillingModeSummary"]["BillingMode"] == "PROVISIONED"
   end
 
   test "update_table" do


### PR DESCRIPTION
This PR will resolve issue #48, which was the bug we ran into when onboarding our new devs and trying to run migrations.  The new devs were running local DDB version `1.11.478`, while the rest of us were most likely on `1.11.477` (at least I was).

Production and local DDB have a new behavior, which is that a `describe_table` request against a table with provisioned billing mode will no longer return a value under the `"BillingModeSummary` key (this was not apparent in their documentation, but I tested against production and can confirm that this is the behavior).  We have some logic that smooths out some little snags in local DDB when dealing with non-existent provisioned throughput for a provisioned table - there's some conditional logic there that was expecting to find a value under `["BillingModeSummary"]["BillingMode"]` on a provisioned table, which used to be the case - so now it instead checks for the presence of a `"BillingModeSummary"` key to determine which type of table it's dealing with.

I opted to leave the original condition in as well, so we can cover people who may still be running the older version of local DDB, and I'm curious to hear what you think about that - I'm actually not sure I think we should, since **a)** their local versions of DDB no longer reflect the behavior that's available to them in production, and **b)** it's super-easy to upgrade your version of local DDB.

(this latest version of DDB local was released this past January)

This PR should be considered a "work in progress" for the time being - once we're all satisfied with the changes I've made here, I'd also like to update the documentation/comments with some information about this issue.