### PR TITLE
Batch

### DIFF
--- a/lib/ecto_adapters_dynamodb/query.ex
+++ b/lib/ecto_adapters_dynamodb/query.ex
@@ -138,11 +138,9 @@ defmodule Ecto.Adapters.DynamoDB.Query do
     end
   end
   defp passes_filter?(item, [{ _logical_op, [ filter_clause ]}])do
-    IO.puts "damn"
     passes_filter?(item, filter_clause)
   end
   defp passes_filter?(item, filter) do
-    IO.puts "shit"
     passes_filter?(item, [ filter ])
   end
 
@@ -188,8 +186,10 @@ defmodule Ecto.Adapters.DynamoDB.Query do
   # The initial 'search' arg will have a list of all of the values being queried for;
   # when passing this data to construct_batch_get_item_query/5 during a batched operation,
   # use a modified form of the 'search' arg that contains only the values from the current batch.
-  defp make_batched_search([and: [range_query, {hash_key, {_vals, op}}]], hash_batch), do: [{hash_key, {hash_batch, op}}, range_query]
-  defp make_batched_search([{index, {_vals, op}}], hash_batch), do: [{index, {hash_batch, op}}]
+  defp make_batched_search([and: [range_query, {hash_key, {_vals, op}}]], hash_batch),
+    do: [{hash_key, {hash_batch, op}}, range_query]
+  defp make_batched_search([{index, {_vals, op}}], hash_batch),
+    do: [{index, {hash_batch, op}}]
 
   @doc """
   Returns an atom, :scan or :query, specifying whether the current search will be a DynamoDB scan or a query.

--- a/lib/ecto_adapters_dynamodb/query.ex
+++ b/lib/ecto_adapters_dynamodb/query.ex
@@ -117,23 +117,11 @@ defmodule Ecto.Adapters.DynamoDB.Query do
       else: %{}
   end
   defp filter(%{"Responses" => items} = result, non_indexed_filters, table) do
-    filtered_results = Enum.filter(items[table], fn item -> passes_filter?(item, non_indexed_filters) end)
+    filtered_results = Enum.filter(items[table], &passes_filter?(&1, non_indexed_filters))
     put_in(result, ["Responses", table], filtered_results)
   end
 
 
-  defp passes_filter?(item, [{ logical_op, [ filter_clauses | [ additional_filter_clauses ] ] }]) do
-    case logical_op do
-      :and -> passes_filter?(item, filter_clauses) and passes_filter?(item, additional_filter_clauses)
-      :or -> passes_filter?(item, filter_clauses) or passes_filter?(item, additional_filter_clauses)
-    end
-  end
-  defp passes_filter?(item, [{ _logical_op, [ filter_clause ]}])do
-    passes_filter?(item, filter_clause)
-  end
-  defp passes_filter?(item, { _logical_op, filter_clause } = filter) when is_list(filter_clause) do
-    passes_filter?(item, [ filter ])
-  end
   defp passes_filter?(item, { field, filter_clause }) when field not in @logical_ops do
     case Map.get(item, field) do
       nil -> evaluate_filter_expression(nil, filter_clause)
@@ -142,6 +130,20 @@ defmodule Ecto.Adapters.DynamoDB.Query do
         |> Decoder.decode()
         |> evaluate_filter_expression(filter_clause)
     end
+  end
+  defp passes_filter?(item, [{ logical_op, [ filter_clauses | [ additional_filter_clauses ] ] }]) do
+    case logical_op do
+      :and -> passes_filter?(item, filter_clauses) and passes_filter?(item, additional_filter_clauses)
+      :or -> passes_filter?(item, filter_clauses) or passes_filter?(item, additional_filter_clauses)
+    end
+  end
+  defp passes_filter?(item, [{ _logical_op, [ filter_clause ]}])do
+    IO.puts "damn"
+    passes_filter?(item, filter_clause)
+  end
+  defp passes_filter?(item, filter) do
+    IO.puts "shit"
+    passes_filter?(item, [ filter ])
   end
 
 

--- a/lib/ecto_adapters_dynamodb/query.ex
+++ b/lib/ecto_adapters_dynamodb/query.ex
@@ -87,6 +87,7 @@ defmodule Ecto.Adapters.DynamoDB.Query do
             ExAws.Dynamo.get_item(table, query, construct_opts(:get_item, opts)) |> ExAws.request!
           end
 
+        # If there are non-indexed searches, we can infer that the results are to be filtered.
         case collect_non_indexed_search(search, indexes, []) do
           [] -> primary_key_results
           non_indexed_filters -> filter(primary_key_results, non_indexed_filters, table)
@@ -136,12 +137,8 @@ defmodule Ecto.Adapters.DynamoDB.Query do
       :or -> evaluate_filter_expression(item, filter) or passes_filter?(item, deeper_clauses)
     end
   end
-  defp passes_filter?(item, [{ _, [ filter ] }]) do
-    evaluate_filter_expression(item, filter)
-  end
-  defp passes_filter?(item, deeper_clauses) do
-    passes_filter?(item , [ deeper_clauses ])
-  end
+  defp passes_filter?(item, [{ _, [ filter ] }]), do: evaluate_filter_expression(item, filter)
+  defp passes_filter?(item, deeper_clauses), do: passes_filter?(item , [ deeper_clauses ])
 
 
   # @spec evaluate_filter_expression(decoded_terms, filter_clause) :: boolean()

--- a/lib/ecto_adapters_dynamodb/query.ex
+++ b/lib/ecto_adapters_dynamodb/query.ex
@@ -128,17 +128,11 @@ defmodule Ecto.Adapters.DynamoDB.Query do
       :or -> passes_filter?(item, filter_clauses) or passes_filter?(item, additional_filter_clauses)
     end
   end
-  defp passes_filter?(item, { logical_op, [ filter_clauses | [ additional_filter_clauses ] ] }) do
-    case logical_op do
-      :and -> passes_filter?(item, filter_clauses) and passes_filter?(item, additional_filter_clauses)
-      :or -> passes_filter?(item, filter_clauses) or passes_filter?(item, additional_filter_clauses)
-    end
-  end
   defp passes_filter?(item, [{ _logical_op, [ filter_clause ]}])do
     passes_filter?(item, filter_clause)
   end
-  defp passes_filter?(item, { _logical_op, [ filter_clause ]}) do
-    passes_filter?(item, filter_clause)
+  defp passes_filter?(item, { _logical_op, filter_clause } = filter) when is_list(filter_clause) do
+    passes_filter?(item, [ filter ])
   end
   defp passes_filter?(item, { field, filter_clause }) when field not in @logical_ops do
     case Map.get(item, field) do

--- a/lib/ecto_adapters_dynamodb/query.ex
+++ b/lib/ecto_adapters_dynamodb/query.ex
@@ -138,7 +138,7 @@ defmodule Ecto.Adapters.DynamoDB.Query do
     end
   end
   defp passes_filter?(item, [{ _, [ filter ] }]), do: evaluate_filter_expression(item, filter)
-  defp passes_filter?(item, deeper_clauses), do: passes_filter?(item , [ deeper_clauses ])
+  defp passes_filter?(item, deeper_clauses_or_filter), do: passes_filter?(item , [ deeper_clauses_or_filter ])
 
 
   # @spec evaluate_filter_expression(decoded_terms, filter_clause) :: boolean()
@@ -159,10 +159,8 @@ defmodule Ecto.Adapters.DynamoDB.Query do
     do: value in filter_val
   defp evaluate_filter_expression(value, { [ range_start, range_end ], :between }),
     do: value >= range_start and value <= range_end
-  defp evaluate_filter_expression(value, { filter_val, :begins_with }) do
-    {:ok, reg} = Regex.compile("^#{filter_val}.*")
-    Regex.match?(reg, value)
-  end
+  defp evaluate_filter_expression(value, { filter_val, :begins_with }),
+    do: String.starts_with?(value, filter_val)
 
 
   # In the case of a partial query on a composite key secondary index, the value of index in get_item/2 will be a three-element tuple, ex. {:secondary_partial, "person_id_entity", ["person_id"]}.

--- a/lib/ecto_adapters_dynamodb/query.ex
+++ b/lib/ecto_adapters_dynamodb/query.ex
@@ -148,20 +148,12 @@ defmodule Ecto.Adapters.DynamoDB.Query do
 
 
   @spec evaluate_filter_expression(decoded_terms, {filters, query_op}) :: boolean()
-  defp evaluate_filter_expression(value, {filter_val, :==}),
-    do: value == filter_val
+  defp evaluate_filter_expression(value, {filter_val, op}) when op in [:==, :<, :<=, :>, :>=],
+    do: apply(Kernel, op, [value, filter_val])
   defp evaluate_filter_expression(value, {_, :is_nil}),
     do: is_nil(value)
   defp evaluate_filter_expression(value, {filter_val, :in}),
     do: value in filter_val
-  defp evaluate_filter_expression(value, {filter_val, :<}),
-    do: value < filter_val
-  defp evaluate_filter_expression(value, {filter_val, :<=}),
-    do: value <= filter_val
-  defp evaluate_filter_expression(value, {filter_val, :>}),
-    do: value > filter_val
-  defp evaluate_filter_expression(value, {filter_val, :>=}),
-    do: value >= filter_val
   defp evaluate_filter_expression(value, {[range_start, range_end], :between}),
     do: value >= range_start and value <= range_end
   defp evaluate_filter_expression(value, {filter_val, :begins_with}) do

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -339,6 +339,24 @@ defmodule Ecto.Adapters.DynamoDB.Test do
               select: p.id)
              |> TestRepo.one() == person.id
 
+      lower_bound = 17
+      upper_bound = 19
+
+      assert from(p in Person,
+              where: p.id == "person:jamesholden"
+                and p.email == "jholden@expanse.com"
+                and p.last_name == "Holden"
+                and fragment("? between ? and ?", p.age, ^lower_bound, ^upper_bound),
+              select: p.id)
+             |> TestRepo.one() == person.id
+
+      refute from(p in Person,
+              where: p.id == "person:jamesholden"
+                and p.email == "wrong@test.com"
+                and fragment("? between ? and ?", p.age, ^lower_bound, ^upper_bound),
+              select: p.id)
+             |> TestRepo.one() == person.id
+
       email_fragment = "wron"
 
       refute from(p in Person,
@@ -397,6 +415,17 @@ defmodule Ecto.Adapters.DynamoDB.Test do
                  or p.first_name == "Larry",
                select: p.id)
              |> TestRepo.all() == [person2.id]
+
+# x = 71
+# y = 73
+#       assert from(p in Person,
+#                where: p.id in ^ids
+#                  and p.last_name == "Howard"
+#                  and is_nil(p.updated_at)
+#                  and is_nil(p.age)
+#                  or fragment("? between ? and ?", p.age, ^x, ^y),
+#                select: p.id)
+#              |> TestRepo.all() == [person2.id]
     end
 
     test "'all... in...' query, hard-coded and a variable lists of composite primary keys" do

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -339,11 +339,14 @@ defmodule Ecto.Adapters.DynamoDB.Test do
               select: p.id)
              |> TestRepo.one() == person.id
 
+      email_fragment = "wron"
+
       refute from(p in Person,
               where: p.id == "person:jamesholden"
                 and p.email == "jholden@expanse.com"
                 and p.age > 17
                 and is_nil(p.country)
+                and fragment("begins_with(?, ?)", p.email, ^email_fragment)
                 and is_nil(p.updated_at)) # we expect updated_at to be not nil.
              |> TestRepo.one()
 
@@ -388,6 +391,8 @@ defmodule Ecto.Adapters.DynamoDB.Test do
 
       assert from(p in Person,
                where: p.id in ^ids
+                 and p.last_name == "Howard"
+                 and is_nil(p.updated_at)
                  and is_nil(p.age))
              |> TestRepo.all() == []
     end

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -342,6 +342,7 @@ defmodule Ecto.Adapters.DynamoDB.Test do
       refute from(p in Person,
               where: p.id == "person:jamesholden"
                 and p.email == "jholden@expanse.com"
+                and p.age > 17
                 and is_nil(p.updated_at))
              |> TestRepo.one()
 

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -393,8 +393,10 @@ defmodule Ecto.Adapters.DynamoDB.Test do
                where: p.id in ^ids
                  and p.last_name == "Howard"
                  and is_nil(p.updated_at)
-                 and is_nil(p.age))
-             |> TestRepo.all() == []
+                 and is_nil(p.age)
+                 or p.first_name == "Larry",
+               select: p.id)
+             |> TestRepo.all() == [person2.id]
     end
 
     test "'all... in...' query, hard-coded and a variable lists of composite primary keys" do

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -343,7 +343,8 @@ defmodule Ecto.Adapters.DynamoDB.Test do
               where: p.id == "person:jamesholden"
                 and p.email == "jholden@expanse.com"
                 and p.age > 17
-                and is_nil(p.updated_at))
+                and is_nil(p.country)
+                and is_nil(p.updated_at)) # we expect updated_at to be not nil.
              |> TestRepo.one()
 
       refute from(p in Person,

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -377,11 +377,17 @@ defmodule Ecto.Adapters.DynamoDB.Test do
                select: p.id)
              |> TestRepo.all()
              |> Enum.sort() == sorted_ids
+
       assert from(p in Person,
                where: p.id in ["person-moe", "person-larry"],
                select: p.id)
              |> TestRepo.all()
              |> Enum.sort() == sorted_ids
+
+      assert from(p in Person,
+               where: p.id in ^ids
+                 and is_nil(p.age))
+             |> TestRepo.all() == []
     end
 
     test "'all... in...' query, hard-coded and a variable lists of composite primary keys" do

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -396,6 +396,18 @@ defmodule Ecto.Adapters.DynamoDB.Test do
       sorted_ids = Enum.sort(ids)
 
       assert from(p in Person,
+               where: p.id == "person-larry"
+                 and p.first_name == "Joe")
+             |> TestRepo.all() == []
+
+      assert from(p in Person,
+               where: p.id in ["person-larry", "person-not-exists"]
+                  and p.first_name == "Joe"
+                   or p.age >= 72,
+               select: p.id)
+             |> TestRepo.all() == [person2.id]
+
+      assert from(p in Person,
                where: p.id in ^ids,
                select: p.id)
              |> TestRepo.all()


### PR DESCRIPTION
This is my first crack at an alternate solution for #47, in which I've followed @alhambra1's suggestion to post-filter `get-item` and `batch-get-item` requests rather than `query` when filter conditions are present but a primary-key lookup is possible.

First off, a little context for clarity... primary key lookups in DDB are extremely efficient, and are executed via DDB's `get-item` and `batch-get-item` methods. However, if a DDB user wanted to do a primary key lookup that included filter conditions, they would typically have to use a DDB `query` instead, which is much less efficient.  If the adapter receives an Ecto query like:

```
from(t in Table,
  where: t.id in ^ids
    and is_nil(t.deleted_at))
|> Repo.all()
```

we can actually "beat" the performance expectation of using a DDB `query` in this case (as my original solution did) by instead using a `batch-get-item` request and then post-filtering the data.

In the issue thread, I documented the results of some benchmarking, which strongly suggests that post-filtering a `batch-get-item` request is tremendously more efficient than using a `query` for a batch of 136 records (with about 24 filtered out) - 127.58 milliseconds vs 5.50 seconds, respectively. In fact, the post-filtered `batch-get-item` request actually slightly outperformed an unfiltered `batch-get-item` request for the same set of records, likely due to the fact that fewer records had to be fully decoded for the final returned result (134.03 milliseconds).

The main workhorse in this algorithm is `Query.passes_filter?/2` which receives an item and a set of non-indexed filter clauses. Here are some examples of what those arguments might look like:

```
# item

%{
   "addresses" => %{"L" => []},
   "age" => %{"N" => "18"},
   "data1" => %{"NULL" => true},
   "email" => %{"S" => "jholden@expanse.com"},
   "first_name" => %{"S" => "James"},
   "id" => %{"S" => "person:jamesholden"},
   "inserted_at" => %{"S" => "2020-04-07T01:24:21.914383Z"},
   "last_name" => %{"S" => "Holden"},
   "updated_at" => %{"S" => "2020-04-07T01:24:21.914383Z"}
}

%{
   "addresses" => %{"L" => []},
   "age" => %{"N" => "72"},
   "data1" => %{"NULL" => true},
   "email" => %{"S" => "larry@stooges.com"},
   "first_name" => %{"S" => "Larry"},
   "id" => %{"S" => "person-larry"},
   "inserted_at" => %{"NULL" => true},
   "last_name" => %{"S" => "Fine"},
   "updated_at" => %{"NULL" => true}
}


# non_indexed_filters

[and: [{"updated_at", {"null", :is_nil}}]]


[
  or: [
    {:and,
     [
       {:and,
        [
          {:and, [{"last_name", {"Howard", :==}}]},
          {"updated_at", {"null", :is_nil}}
        ]},
       {"age", {"null", :is_nil}}
     ]},
    {"first_name", {"Larry", :==}}
  ]
]


[
  and: [
    {:and,
     [
       {:and,
        [
          {:and,
           [
             {:and, [{"email", {"jholden@expanse.com", :==}}]},
             {"age", {17, :>}}
           ]},
          {"data1", {"null", :is_nil}}
        ]},
       {"email", {"wron", :begins_with}}
     ]},
    {"updated_at", {"null", :is_nil}}
  ]
]
```

Thanks for taking a look. Let's consider this a work-in-progress, and not merge it until everyone's happy (oh cool, I see that Github has the ability to create a "draft" PR).