### PR TITLE
release_candidate -> master

### DIFF
--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -331,24 +331,6 @@ defmodule Ecto.Adapters.DynamoDB.Test do
                select: p.id)
              |> TestRepo.all()
              |> Enum.at(0) == person.id
-
-      assert from(p in Person,
-              where: p.id == "person:jamesholden"
-                and p.email == "wrong@test.com"
-                or p.age == 18,
-              select: p.id)
-             |> TestRepo.one() == person.id
-
-      refute from(p in Person,
-              where: p.id == "person:jamesholden"
-                and p.email == "jholden@expanse.com"
-                and is_nil(p.updated_at))
-             |> TestRepo.one()
-
-      refute from(p in Person,
-              where: p.id == "person:jamesholden"
-                and is_nil(p.updated_at))
-             |> TestRepo.one()
     end
 
     test "'all... in...' query, hard-coded and a variable list of primary hash keys" do
@@ -595,15 +577,6 @@ defmodule Ecto.Adapters.DynamoDB.Test do
              from(p in Planet,
                where: p.id == ^planet_1.id)
              |> TestRepo.all()
-      # We'd expect inserted_at to be nil, since this was created by an insert_all operation
-      assert from(p in Planet,
-               where: p.id == ^planet_2.id
-                 and is_nil(p.inserted_at))
-             |> TestRepo.one()
-      refute from(p in Planet,
-               where: p.id == ^planet_2.id
-                 and is_nil(p.moons))
-             |> TestRepo.one()
     end
 
     test "get multiple records on a partial secondary index composite key (hash only)" do


### PR DESCRIPTION
This PR removes a partially completed behavior that I had begun to implement in favor of publishing a new major version release.

In brief summary, I implemented behavior around a function named `should_query?()` to address issue #43 - however, this solution only applied to single record primary key lookups, where we really need a solution that handles single- and multi-key lookups - assuming that we decide to support those behaviors at all (described in issue #47). This PR removes the `should_query?()` logic in favor of publishing a new major version release with Ecto 3 support - we can decide if and how to handle #47 at a later date.

If this PR is accepted, I plan to publish it as a version 2.0.0 release.