### PR TITLE
Make the adapter use its own config only for its own calls rather than clobbering the entire :ex_aws_application config.

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,11 +209,13 @@ Configuring a repository to use the DynamoDB ecto adapter is pretty similar to m
 
 These values are **different** from the normal Ecto options. For example, in DynamoDB you don't have `username`, `password`, or `database` options - you'll need to delete these lines. Instead you'll add Amazon `access_key_id`, `secret_access_key`, `region`, and the optional `dynamodb` `host` and `scheme` options if you're not running against the default live Amazon instances (for example, running the local Amazon dev version of DynamoDB for testing and development).
 
-All these options are quietly passed through to ExAws. See [ExAws Getting Started](https://hexdocs.pm/ex_aws/ExAws.html#module-getting-started) for more information on these options.
+All these options are quietly passed through to ExAws. Prior to version 3, existing ExAws configuration would be overwritten by these options. From version 3, the options are only used in calls made by the adapter, and other global ExAws configuration is maintained. See [ExAws Getting Started](https://hexdocs.pm/ex_aws/ExAws.html#module-getting-started) for more information on these options.
 
 A note on `access_key_id` and `secret_access_key`: This can simply be the actual key string, or it can be set to pull these from environment variables or Amazon roles (as per ExAws configuration). Some basic examples follow.
 
 You may also omit all these ExAws options from the adapter config if you wish to configure ExAws manually (for example if you're using other features from ExAws such as S3, or dynamo_streams).
+
+Note that as of version 3, with the exception of logging configuration, all config options are set *per-repo*.
 
 **config/config.exs**
 
@@ -272,7 +274,7 @@ For development, we use the [local version](http://docs.aws.amazon.com/amazondyn
 
 **config/dev.exs**
 
-```elixir               
+```elixir
 config :my_app, MyApp.Repo,
   # ExAws configuration
   access_key_id: "abcd",
@@ -310,7 +312,7 @@ config :my_app, MyApp.Repo,
 The following are adapter options that apply to the Ecto adapter, and are NOT related to ExAws configuration. They control certain behavioural aspects for the driver, enabling and disabling default behaviours and features on queries.
 
 ```elixir
-config :ecto_adapters_dynamodb,
+config :ecto_adapters_dynamodb, MyApp.Repo
   dynamodb_local: true,
   insert_nil_fields: false,
   remove_nil_fields_on_update: true,
@@ -355,18 +357,6 @@ Determines if fields in the changeset with `nil` values will be inserted as Dyna
 
 Determines if, during **Repo.update** or **Repo.update_all**, fields in the changeset with `nil` values will be removed from the record/s or set to the DynamoDB `null` value. This option is also available inline per query.
 
-#### Logging Configuration
-
-The adapter's logging options are configured during compile time, and can be altered in the application's configuration files (`config/config.exs`, `config/dev.exs`, `config/test.exs` and `config/test.exs`). To enable logging in colour, the `MIX_ENV` environment variable must be explicitly exported as `dev` during compilation.
-
-We provide a few informational log lines, such as which adapter call is being processed, as well as the table, lookup fields, and options detected. Configure an optional log path to have the messages recorded on file.
-
-**:log_levels** :: `[:info, :debug]`, *default:* `[:info]`
-
-**:log_colours** :: %{log-level-atom: IO.ANSI-colour-atom}, *default:* `info: :green, debug: :normal`
-
-**:log_path** :: string, *default:* `""`
-
 #### Scan-related options
 
 **:scan_tables** :: [string], *default:* `[]`
@@ -402,6 +392,27 @@ The maximum wait time in milliseconds over sequential retries of a particular **
 **:migration_table_capacity** :: [integer, integer], *default:* `[1,1]`
 
 ProvisionedThroughput as `[ReadCapacityUnits, WriteCapacityUnits]`, for the Schema Migrations table only, automatically created by Ecto if it does not exist.
+
+#### Logging Configuration
+
+The adapter's logging options are configured during compile time, and can be altered in the application's configuration files (`config/config.exs`, `config/dev.exs`, `config/test.exs` and `config/test.exs`). To enable logging in colour, the `MIX_ENV` environment variable must be explicitly exported as `dev` during compilation.
+
+We provide a few informational log lines, such as which adapter call is being processed, as well as the table, lookup fields, and options detected. Configure an optional log path to have the messages recorded on file.
+
+Note that logging configuration is at the adapter level and is common to all repos.
+
+**:log_levels** :: `[:info, :debug]`, *default:* `[:info]`
+
+**:log_colours** :: %{log-level-atom: IO.ANSI-colour-atom}, *default:* `info: :green, debug: :normal`
+
+**:log_path** :: string, *default:* `""`
+
+Example:
+
+```elixir
+config :ecto_adapters_dynamodb,
+  log_levels: [:info, :debug]
+```
 
 ## Inline Options
 
@@ -567,9 +578,13 @@ Documentation can be generated with [ExDoc](https://github.com/elixir-lang/ex_do
 
 Please see the instructions [here](/upgrade_guides/version_1_upgrade_guide.md)
 
-### 0.X.X -> 2.X.X
+### 1.X.X -> 2.X.X
 
 Please see the instructions [here](/upgrade_guides/version_2_upgrade_guide.md)
+
+### 2.X.X -> 3.X.X
+
+Please see the instructions [here](/upgrade_guides/version_3_upgrade_guide.md)
 
 # License
 Copyright Circles Learning Labs

--- a/README.md
+++ b/README.md
@@ -314,7 +314,7 @@ config :my_app, MyApp.Repo,
 The following are adapter options that apply to the Ecto adapter, and are NOT related to ExAws configuration. They control certain behavioural aspects for the driver, enabling and disabling default behaviours and features on queries.
 
 ```elixir
-config :ecto_adapters_dynamodb, MyApp.Repo
+config :my_app, MyApp.Repo
   dynamodb_local: true,
   insert_nil_fields: false,
   remove_nil_fields_on_update: true,

--- a/README.md
+++ b/README.md
@@ -217,6 +217,8 @@ You may also omit all these ExAws options from the adapter config if you wish to
 
 Note that as of version 3, with the exception of logging configuration, all config options are set *per-repo*.
 
+The adapter also supports [Confex](https://hexdocs.pm/confex)-style configuration options.
+
 **config/config.exs**
 
 Include the repo module that's configured for the adapter among the project's Ecto repos:

--- a/config/test.exs
+++ b/config/test.exs
@@ -2,7 +2,6 @@ use Mix.Config
 
 config :ecto_adapters_dynamodb, Ecto.Adapters.DynamoDB.TestRepo,
   migration_source: "test_schema_migrations",
-  # ExAws configuration
   debug_requests: true,
   # Unlike for prod config, we hardcode fake values for local version of DynamoDB
   access_key_id: "abcd",
@@ -13,12 +12,12 @@ config :ecto_adapters_dynamodb, Ecto.Adapters.DynamoDB.TestRepo,
     host: "localhost",
     port: 8000,
     region: "us-east-1"
-  ]
+  ],
+  scan_tables: ["test_schema_migrations"],
+  dynamodb_local: true
 
 config :ecto_adapters_dynamodb,
-  dynamodb_local: true,
-  log_levels: [],
-  scan_tables: ["test_schema_migrations"]
+  log_levels: []
 
 config :logger,
   backends: [:console],

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :test_app, Ecto.Adapters.DynamoDB.TestRepo,
+config :ecto_adapters_dynamodb, Ecto.Adapters.DynamoDB.TestRepo,
   migration_source: "test_schema_migrations",
   debug_requests: true,
   # Unlike for prod config, we hardcode fake values for local version of DynamoDB

--- a/config/test.exs
+++ b/config/test.exs
@@ -1,6 +1,6 @@
 use Mix.Config
 
-config :ecto_adapters_dynamodb, Ecto.Adapters.DynamoDB.TestRepo,
+config :test_app, Ecto.Adapters.DynamoDB.TestRepo,
   migration_source: "test_schema_migrations",
   debug_requests: true,
   # Unlike for prod config, we hardcode fake values for local version of DynamoDB

--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -36,8 +36,6 @@ defmodule Ecto.Adapters.DynamoDB do
       migration_source: Keyword.get(config, :migration_source, "schema_migrations")
     }
 
-    # Pass some config values through to ex_aws.
-
     ecto_dynamo_log(:debug, "#{inspect(__MODULE__)}.init", %{
       "#{inspect(__MODULE__)}.init-params" => %{config: config}
     })

--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -1617,12 +1617,12 @@ defmodule Ecto.Adapters.DynamoDB do
   Logs message to console and optionally to file. Log levels, colours and file path may be set in configuration (details in README.md).
   """
   def ecto_dynamo_log(level, message, attributes \\ %{}, opts \\ []) do
-    log_levels = Application.get_env(:ecto_adapters_dynamodb, :log_levels) || [:info]
+    log_levels = Confex.get_env(:ecto_adapters_dynamodb, :log_levels) || [:info]
 
     if level in log_levels do
-      log_path = Application.get_env(:ecto_adapters_dynamodb, :log_path)
+      log_path = Confex.get_env(:ecto_adapters_dynamodb, :log_path)
       depth = opts[:depth] || 4
-      colours = Application.get_env(:ecto_adapters_dynamodb, :log_colours)
+      colours = Confex.get_env(:ecto_adapters_dynamodb, :log_colours)
       d = DateTime.utc_now()
 
       formatted_message =
@@ -1633,7 +1633,7 @@ defmodule Ecto.Adapters.DynamoDB do
       {:ok, log_message} =
         Jason.encode(%{message: formatted_message, attributes: chisel(attributes, depth)})
 
-      if Application.get_env(:ecto_adapters_dynamodb, :log_in_colour) do
+      if Confex.get_env(:ecto_adapters_dynamodb, :log_in_colour) do
         IO.ANSI.format([colours[level] || :normal, log_message], true) |> IO.puts()
       else
         log_message |> IO.puts()
@@ -1645,9 +1645,11 @@ defmodule Ecto.Adapters.DynamoDB do
   end
 
   def ex_aws_config(repo) do
-    repo.config()
+    config = Confex.get_env(:ecto_adapters_dynamodb, repo)
+
+    config
     |> Keyword.take([:debug_requests, :access_key_id, :secret_access_key, :region])
-    |> Keyword.merge(Keyword.get(repo.config(), :dynamodb, []))
+    |> Keyword.merge(Keyword.get(config, :dynamodb, []))
   end
 
   defp chisel(str, _depth) when is_binary(str), do: str

--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -14,6 +14,7 @@ defmodule Ecto.Adapters.DynamoDB do
 
   use Bitwise, only_operators: true
 
+  alias Confex.Resolver
   alias Ecto.Adapters.DynamoDB.Cache
   alias Ecto.Adapters.DynamoDB.RepoConfig
   alias Ecto.Query.BooleanExpr
@@ -1645,7 +1646,7 @@ defmodule Ecto.Adapters.DynamoDB do
   end
 
   def ex_aws_config(repo) do
-    config = Confex.get_env(:ecto_adapters_dynamodb, repo)
+    config = Resolver.resolve!(repo.config())
 
     config
     |> Keyword.take([:debug_requests, :access_key_id, :secret_access_key, :region])

--- a/lib/ecto_adapters_dynamodb/application.ex
+++ b/lib/ecto_adapters_dynamodb/application.ex
@@ -12,7 +12,6 @@ defmodule Ecto.Adapters.DynamoDB.Application do
     children = [
       # Starts a worker by calling: Ecto.Adapters.DynamoDB.Worker.start_link(arg1, arg2, arg3)
       # worker(Ecto.Adapters.DynamoDB.Worker, [arg1, arg2, arg3]),
-      worker(Ecto.Adapters.DynamoDB.Cache, []),
       worker(Ecto.Adapters.DynamoDB.QueryInfo, [])
     ]
 

--- a/lib/ecto_adapters_dynamodb/cache.ex
+++ b/lib/ecto_adapters_dynamodb/cache.ex
@@ -6,6 +6,7 @@ defmodule Ecto.Adapters.DynamoDB.Cache do
   @typep table_name_t :: String.t()
   @typep dynamo_response_t :: %{required(String.t()) => term}
 
+  alias Confex.Resolver
   alias Ecto.Adapters.DynamoDB
   alias Ecto.Repo
 
@@ -15,9 +16,10 @@ defmodule Ecto.Adapters.DynamoDB.Cache do
     :ex_aws_config
   ]
 
+  @type cached_table :: {String.t(), map()}
   @type t :: %__MODULE__{
-          schemas: Map.t(),
-          tables: [CachedTable.t()]
+          schemas: map(),
+          tables: [cached_table()]
         }
 
   def child_spec([repo]) do
@@ -30,8 +32,8 @@ defmodule Ecto.Adapters.DynamoDB.Cache do
   @spec start_link(Repo.t()) :: Agent.on_start()
   def start_link(repo) do
     cached_table_list =
-      :ecto_adapters_dynamodb
-      |> Confex.get_env(repo)
+      repo.config()
+      |> Resolver.resolve!()
       |> Keyword.get(:cached_tables, [])
 
     Agent.start_link(

--- a/lib/ecto_adapters_dynamodb/cache.ex
+++ b/lib/ecto_adapters_dynamodb/cache.ex
@@ -31,7 +31,7 @@ defmodule Ecto.Adapters.DynamoDB.Cache do
   def start_link(repo) do
     cached_table_list =
       :ecto_adapters_dynamodb
-      |> Application.get_env(repo)
+      |> Confex.get_env(repo)
       |> Keyword.get(:cached_tables, [])
 
     Agent.start_link(

--- a/lib/ecto_adapters_dynamodb/repo_config.ex
+++ b/lib/ecto_adapters_dynamodb/repo_config.ex
@@ -1,14 +1,16 @@
 defmodule Ecto.Adapters.DynamoDB.RepoConfig do
+  alias Confex.Resolver
+
   def table_in_list?(repo, table, list) do
-    :ecto_adapters_dynamodb
-    |> Confex.get_env(repo)
+    repo.config()
+    |> Resolver.resolve!()
     |> Keyword.get(list, [])
     |> Enum.member?(table)
   end
 
   def config_val(repo, key, default \\ nil) do
-    :ecto_adapters_dynamodb
-    |> Confex.get_env(repo)
+    repo.config()
+    |> Resolver.resolve!()
     |> Keyword.get(key, default)
   end
 end

--- a/lib/ecto_adapters_dynamodb/repo_config.ex
+++ b/lib/ecto_adapters_dynamodb/repo_config.ex
@@ -1,14 +1,14 @@
 defmodule Ecto.Adapters.DynamoDB.RepoConfig do
   def table_in_list?(repo, table, list) do
     :ecto_adapters_dynamodb
-    |> Application.get_env(repo)
+    |> Confex.get_env(repo)
     |> Keyword.get(list, [])
     |> Enum.member?(table)
   end
 
   def config_val(repo, key, default \\ nil) do
     :ecto_adapters_dynamodb
-    |> Application.get_env(repo)
+    |> Confex.get_env(repo)
     |> Keyword.get(key, default)
   end
 end

--- a/lib/ecto_adapters_dynamodb/repo_config.ex
+++ b/lib/ecto_adapters_dynamodb/repo_config.ex
@@ -1,0 +1,14 @@
+defmodule Ecto.Adapters.DynamoDB.RepoConfig do
+  def table_in_list?(repo, table, list) do
+    :ecto_adapters_dynamodb
+    |> Application.get_env(repo)
+    |> Keyword.get(list, [])
+    |> Enum.member?(table)
+  end
+
+  def config_val(repo, key, default \\ nil) do
+    :ecto_adapters_dynamodb
+    |> Application.get_env(repo)
+    |> Keyword.get(key, default)
+  end
+end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ecto.Adapters.DynamoDB.Mixfile do
   def project do
     [
       app: :ecto_adapters_dynamodb,
-      version: "2.0.4",
+      version: "3.0.0",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/mix.exs
+++ b/mix.exs
@@ -53,6 +53,7 @@ defmodule Ecto.Adapters.DynamoDB.Mixfile do
   # Type "mix help deps" for more examples and options
   defp deps do
     [
+      {:confex, "~> 3.5.0"},
       {:ecto_sql, "~> 3.4"},
       {:ex_aws_dynamo, "~> 3.0"},
       {:jason, "~> 1.0"},

--- a/mix.lock
+++ b/mix.lock
@@ -1,5 +1,6 @@
 %{
   "certifi": {:hex, :certifi, "2.5.3", "70bdd7e7188c804f3a30ee0e7c99655bc35d8ac41c23e12325f36ab449b70651", [:rebar3], [{:parse_trans, "~>3.3", [hex: :parse_trans, repo: "hexpm", optional: false]}], "hexpm", "ed516acb3929b101208a9d700062d520f3953da3b6b918d866106ffa980e1c10"},
+  "confex": {:hex, :confex, "3.5.0", "163857c73dd8f88a3815663f4bc00bee1b9c65daf40aa6e0d6ef272757fd22c7", [:mix], [], "hexpm", "34a9e31230c7fbb3dbe60db00341d0c84ee44ba3caf84b498f501c0bc8563570"},
   "connection": {:hex, :connection, "1.0.4", "a1cae72211f0eef17705aaededacac3eb30e6625b04a6117c1b2db6ace7d5976", [:mix], [], "hexpm", "4a0850c9be22a43af9920a71ab17c051f5f7d45c209e40269a1938832510e4d9"},
   "db_connection": {:hex, :db_connection, "2.2.2", "3bbca41b199e1598245b716248964926303b5d4609ff065125ce98bcd368939e", [:mix], [{:connection, "~> 1.0.2", [hex: :connection, repo: "hexpm", optional: false]}], "hexpm", "642af240d8a8affb93b4ba5a6fcd2bbcbdc327e1a524b825d383711536f8070c"},
   "decimal": {:hex, :decimal, "1.8.1", "a4ef3f5f3428bdbc0d35374029ffcf4ede8533536fa79896dd450168d9acdf3c", [:mix], [], "hexpm", "3cb154b00225ac687f6cbd4acc4b7960027c757a5152b369923ead9ddbca7aec"},

--- a/test/ecto_adapters_dynamodb/info_test.exs
+++ b/test/ecto_adapters_dynamodb/info_test.exs
@@ -5,7 +5,17 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
 
   use ExUnit.Case
 
-  import import Ecto.Adapters.DynamoDB.Info
+  import Ecto.Adapters.DynamoDB.Info
+
+  alias Ecto.Adapters.DynamoDB.TestRepo
+
+  setup_all do
+    TestHelper.setup_all()
+
+    on_exit(fn ->
+      TestHelper.on_exit()
+    end)
+  end
 
   test "table_info" do
     assert %{
@@ -47,7 +57,7 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
              "TableArn" => "arn:aws:dynamodb:ddblocal:000000000000:table/test_planet",
              "TableName" => "test_planet",
              "TableStatus" => "ACTIVE"
-           } = table_info("test_planet")
+           } = table_info(TestRepo, "test_planet")
   end
 
   test "index_details" do
@@ -134,11 +144,11 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
                  }
                }
              ]
-           } = index_details("test_person")
+           } = index_details(TestRepo, "test_person")
   end
 
   test "indexes" do
-    assert indexes("test_person") == [
+    assert indexes(TestRepo, "test_person") == [
              {:primary, ["id"]},
              {"first_name_age", ["first_name", "age"]},
              {"age_first_name", ["age", "first_name"]},
@@ -149,7 +159,7 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
   end
 
   test "primary_key!" do
-    assert primary_key!("test_planet") == {:primary, ["id", "name"]}
+    assert primary_key!(TestRepo, "test_planet") == {:primary, ["id", "name"]}
   end
 
   test "repo_primary_key" do
@@ -163,7 +173,7 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
   end
 
   test "secondary_indexes" do
-    assert secondary_indexes("test_person") == [
+    assert secondary_indexes(TestRepo, "test_person") == [
              {"first_name_age", ["first_name", "age"]},
              {"age_first_name", ["age", "first_name"]},
              {"first_name", ["first_name"]},
@@ -173,6 +183,6 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
   end
 
   test "indexed_attributes" do
-    assert indexed_attributes("test_planet") == ["id", "name", "mass"]
+    assert indexed_attributes(TestRepo, "test_planet") == ["id", "name", "mass"]
   end
 end

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -7,6 +7,7 @@ defmodule Ecto.Adapters.DynamoDB.Test do
 
   import Ecto.Query
 
+  alias Ecto.Adapters.DynamoDB
   alias Ecto.Adapters.DynamoDB.TestRepo
   alias Ecto.Adapters.DynamoDB.TestSchema.{Person, Address, BookPage, Planet, Fruit}
 
@@ -84,11 +85,11 @@ defmodule Ecto.Adapters.DynamoDB.Test do
 
       %{"Item" => earth_result} =
         ExAws.Dynamo.get_item("test_planet", %{id: earth.id, name: earth.name})
-        |> ExAws.request!()
+        |> request!()
 
       %{"Item" => venus_result} =
         ExAws.Dynamo.get_item("test_planet", %{id: venus.id, name: venus.name})
-        |> ExAws.request!()
+        |> request!()
 
       refute Map.has_key?(earth_result, "moons")
       assert Map.has_key?(venus_result, "moons")
@@ -127,8 +128,7 @@ defmodule Ecto.Adapters.DynamoDB.Test do
       |> Ecto.Changeset.change(country: "USA", last_name: nil)
       |> TestRepo.update(remove_nil_fields_on_update: true)
 
-      %{"Item" => result} =
-        ExAws.Dynamo.get_item("test_person", %{id: person.id}) |> ExAws.request!()
+      %{"Item" => result} = ExAws.Dynamo.get_item("test_person", %{id: person.id}) |> request!()
 
       refute Map.has_key?(result, "last_name")
     end
@@ -527,7 +527,7 @@ defmodule Ecto.Adapters.DynamoDB.Test do
         )
 
       assert_raise ArgumentError,
-                   "Ecto.Adapters.DynamoDB.Query.get_matching_secondary_index/3 error: :index option does not match existing secondary index names. Did you mean age_first_name?",
+                   "Ecto.Adapters.DynamoDB.Query.get_matching_secondary_index/4 error: :index option does not match existing secondary index names. Did you mean age_first_name?",
                    fn ->
                      query
                      |> TestRepo.all(index: "age_first_nam")
@@ -766,4 +766,6 @@ defmodule Ecto.Adapters.DynamoDB.Test do
       do: :"#{base_type}_usec",
       else: base_type
   end
+
+  defp request!(operation), do: ExAws.request!(operation, DynamoDB.ex_aws_config(TestRepo))
 end

--- a/test/integration/ex_aws_dynamo_test.exs
+++ b/test/integration/ex_aws_dynamo_test.exs
@@ -5,6 +5,8 @@ defmodule Ecto.Adapters.DynamoDB.Integration.ExAws.Dynamo.Test do
 
   use ExUnit.Case
 
+  alias Ecto.Adapters.DynamoDB
+  alias Ecto.Adapters.DynamoDB.TestRepo
   alias ExAws.Dynamo
 
   @ex_aws_dynamo_test_table_name "ex_aws_dynamo_test_table"
@@ -17,26 +19,24 @@ defmodule Ecto.Adapters.DynamoDB.Integration.ExAws.Dynamo.Test do
       1,
       1
     )
-    |> ExAws.request!()
+    |> request!()
 
-    {:ok, table_info} =
-      ExAws.Dynamo.describe_table(@ex_aws_dynamo_test_table_name) |> ExAws.request()
+    {:ok, table_info} = ExAws.Dynamo.describe_table(@ex_aws_dynamo_test_table_name) |> request()
 
     assert table_info["Table"]["TableName"] == @ex_aws_dynamo_test_table_name
   end
 
   test "update_table" do
     Dynamo.update_table(@ex_aws_dynamo_test_table_name, billing_mode: :pay_per_request)
-    |> ExAws.request!()
+    |> request!()
 
-    {:ok, table_info} =
-      ExAws.Dynamo.describe_table(@ex_aws_dynamo_test_table_name) |> ExAws.request()
+    {:ok, table_info} = ExAws.Dynamo.describe_table(@ex_aws_dynamo_test_table_name) |> request()
 
     assert table_info["Table"]["BillingModeSummary"]["BillingMode"] == "PAY_PER_REQUEST"
   end
 
   test "delete_table" do
-    result = Dynamo.delete_table(@ex_aws_dynamo_test_table_name) |> ExAws.request!()
+    result = Dynamo.delete_table(@ex_aws_dynamo_test_table_name) |> request!()
 
     assert result["TableDescription"]["TableName"] == @ex_aws_dynamo_test_table_name
   end
@@ -62,4 +62,7 @@ defmodule Ecto.Adapters.DynamoDB.Integration.ExAws.Dynamo.Test do
     assert Dynamo.Decoder.decode(%{"NS" => ["1", "2", "3"]}) == MapSet.new([1, 2, 3])
     assert Dynamo.Decoder.decode(%{"L" => [%{"S" => "asdf"}, %{"N" => "1"}]}) == ["asdf", 1]
   end
+
+  defp request(request), do: ExAws.request(request, DynamoDB.ex_aws_config(TestRepo))
+  defp request!(request), do: ExAws.request!(request, DynamoDB.ex_aws_config(TestRepo))
 end

--- a/test/support/test_repo.ex
+++ b/test/support/test_repo.ex
@@ -1,5 +1,5 @@
 defmodule Ecto.Adapters.DynamoDB.TestRepo do
   use Ecto.Repo,
-    otp_app: :ecto_adapters_dynamodb,
+    otp_app: :test_app,
     adapter: Ecto.Adapters.DynamoDB
 end

--- a/test/support/test_repo.ex
+++ b/test/support/test_repo.ex
@@ -1,5 +1,5 @@
 defmodule Ecto.Adapters.DynamoDB.TestRepo do
   use Ecto.Repo,
-    otp_app: :test_app,
+    otp_app: :ecto_adapters_dynamodb,
     adapter: Ecto.Adapters.DynamoDB
 end

--- a/upgrade_guides/version_3_upgrade_guide.md
+++ b/upgrade_guides/version_3_upgrade_guide.md
@@ -1,0 +1,38 @@
+# Upgrading from version 2.X.X -> 3.X.X
+
+## Config changes
+
+With the exception of logging configuration, all config options are now per-repo. For example:
+
+```elixir
+config :ecto_adapters_dynamodb,
+  dynamodb: [
+    scheme: "http://",
+    host: "localhost",
+    port: 8000,
+    region: "us-east-1"
+  ],
+  scan_tables: ["test_schema_migrations"]
+```
+
+now needs to be:
+
+```elixir
+config :ecto_adapters_dynamodb, MyApp.MyRepo
+  dynamodb: [
+    scheme: "http://",
+    host: "localhost",
+    port: 8000,
+    region: "us-east-1"
+  ],
+  scan_tables: ["test_schema_migrations"]
+```
+
+(replacing `MyApp.MyRepo` with your repo).
+
+### Global ExAws config
+
+Prior to v3, the adapter would overwrite any existing glboal ExAws config with its own values on
+startup. From v3 the adapter will only use the config it's given in the calls it makes itself.
+This may mean that you need to explicitly specify ExAws configuration options outside of the
+adapter's config if you're making your own ExAws calls elsewhere.


### PR DESCRIPTION
So this is a biggun, but the actual amount of functional change is pretty small. The vast bulk of the changes are just passing the repo around everywhere. That means that, any time we call `ExAws.request/2`, or get config that makes sense to have tied to the repo rather than the adapter, we can get the repo-specific config. The original point of this was just to avoid clobbering the global `ex_aws` config, but I realised that there's no rule against multiple repos, and most of the config makes more sense on a per-repo basis. So I moved basically all of it except the logging config.

I haven't updated the docs yet - I'll do that once we're happy with it all working this way.