### PR TITLE
Maintain backwards compatibility for Ecto 3 minor versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 [v2.x.x -> v3.x.x upgrade guide](/upgrade_guides/version_3_upgrade_guide.md)
 
+## v3.0.1
+
+- Maintain backwards compatibility for Ecto versions 3.0 <= 3.4 - all major version 3 releases of Ecto should now be supported
+
 ## v3.0.0
 
 ### Enhancements

--- a/README.md
+++ b/README.md
@@ -184,7 +184,7 @@ Install the [Hex](https://hex.pm/packages/ecto_adapters_dynamodb) package by add
 ```elixir
 defp deps do
   [
-  	{:ecto_adapters_dynamodb, "~> 2.0"}
+  	{:ecto_adapters_dynamodb, "~> 3.0"}
   ]
 end
 ```
@@ -194,7 +194,7 @@ Otherwise, to fetch from GitHub:
 ```elixir
 defp deps do
   [
-  	{:ecto_adapters_dynamodb, git: "https://github.com/circles-learning-labs/ecto_adapters_dynamodb", tag: "2.0.4"}
+  	{:ecto_adapters_dynamodb, git: "https://github.com/circles-learning-labs/ecto_adapters_dynamodb", tag: "3.0.1"}
   ]
 end
 ```

--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -1543,7 +1543,12 @@ defmodule Ecto.Adapters.DynamoDB do
         t when t in [:naive_datetime_usec, :naive_datetime] ->
           NaiveDateTime.from_iso8601!(val)
 
+        # Support for Ecto >= 3.5
         {:parameterized, _, _} ->
+          decode_embed(val, type)
+
+        # Support for Ecto 3.0 <= 3.4
+        {:embed, _} ->
           decode_embed(val, type)
 
         _ ->

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Ecto.Adapters.DynamoDB.Mixfile do
   def project do
     [
       app: :ecto_adapters_dynamodb,
-      version: "3.0.0",
+      version: "3.0.1",
       elixir: "~> 1.7",
       build_embedded: Mix.env() == :prod,
       start_permanent: Mix.env() == :prod,

--- a/upgrade_guides/version_3_upgrade_guide.md
+++ b/upgrade_guides/version_3_upgrade_guide.md
@@ -37,13 +37,6 @@ startup. From v3 the adapter will only use the config it's given in the calls it
 This may mean that you need to explicitly specify ExAws configuration options outside of the
 adapter's config if you're making your own ExAws calls elsewhere.
 
-## Ecto version
-
-Due to changes in version 3.5 of [Ecto](https://github.com/elixir-ecto/ecto), version 3 of this
-adapter is only compatible with version 3.5 of Ecto or higher. If you are using a lower version
-of Ecto, be aware that upgrading to version 3 of this adapter will necesitate upgrading Ecto to
-3.5 or higher as well.
-
 ## ExAws.Dynamo version
 
 This release of the adapter includes support for the latest major version of [ExAws.Dynamo](


### PR DESCRIPTION
Tested this with latest Ecto as well as the previous version we were on (version 3.4.6), all's well.