### PR TITLE
Add empty MapSet handling for update operations

### DIFF
--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -1191,7 +1191,7 @@ defmodule Ecto.Adapters.DynamoDB do
   defp maybe_list(l) when is_list(l), do: l
   defp maybe_list(_), do: []
 
-  defp format_nil_or_val(_k, v, _opts) when is_nil(v), do: %{"NULL" => "true"}
+  defp format_nil_or_val(_k, nil, _opts), do: %{"NULL" => "true"}
   defp format_nil_or_val(k, v, opts), do: format_val(k, v, opts)
 
   defp format_val(k, v, opts) do

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -135,6 +135,26 @@ defmodule Ecto.Adapters.DynamoDB.Test do
       assert MapSet.equal?(result.tags_to_tags, MapSet.new())
     end
 
+    test "update with nil_to_empty_mapset" do
+      item =
+        %{base_person_record() | tags_to_tags: MapSet.new(["a", "b"])}
+        |> TestRepo.insert!()
+        |> Person.changeset(%{tags_to_tags: MapSet.new()})
+        |> TestRepo.update!(empty_mapset_to_nil: true)
+
+      result = TestRepo.get(Person, item.id, nil_to_empty_mapset: true)
+      assert MapSet.equal?(result.tags_to_tags, MapSet.new())
+    end
+
+    test "update without nil_to_empty_mapset" do
+      assert_raise RuntimeError, "Cannot determine a proper data type for an empty MapSet", fn ->
+        %{base_person_record() | tags_to_tags: MapSet.new(["a", "b"])}
+        |> TestRepo.insert!()
+        |> Person.changeset(%{tags_to_tags: MapSet.new()})
+        |> TestRepo.update!()
+      end
+    end
+
     defp base_person_record() do
       %Person{
         first_name: "Update",

--- a/test/support/test_schema.ex
+++ b/test/support/test_schema.ex
@@ -34,7 +34,7 @@ defmodule Ecto.Adapters.DynamoDB.TestSchema.Person do
 
   def changeset(person, params \\ %{}) do
     person
-    |> Ecto.Changeset.cast(params, [:first_name, :last_name, :age, :email])
+    |> Ecto.Changeset.cast(params, [:first_name, :last_name, :age, :email, :tags_to_tags])
     |> Ecto.Changeset.validate_required([:first_name, :last_name])
     |> Ecto.Changeset.unique_constraint(:id)
   end


### PR DESCRIPTION
The original empty_mapset_to_nil handling missed the `update` case. This fixes it.