### PR TITLE
Revert "Fix reserved word names in delete_all"

### DIFF
--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -342,23 +342,8 @@ defmodule Ecto.Adapters.DynamoDB do
     scan_or_query = Ecto.Adapters.DynamoDB.Query.scan_or_query?(repo, table, lookup_fields)
     recursive = Ecto.Adapters.DynamoDB.Query.parse_recursive_option(scan_or_query, opts)
 
-    projection_expression =
-      key_list
-      |> Enum.map(&("#" <> &1))
-      |> Enum.join(", ")
-
-    expression_attribute_names =
-      key_list
-      |> Enum.map(&{"#" <> &1, &1})
-
     updated_opts =
-      prepare_recursive_opts(
-        opts ++
-          [
-            projection_expression: projection_expression,
-            expression_attribute_names: expression_attribute_names
-          ]
-      )
+      prepare_recursive_opts(opts ++ [projection_expression: Enum.join(key_list, ", ")])
 
     delete_all_recursive(repo, table, lookup_fields, updated_opts, recursive, %{}, 0)
   end

--- a/lib/ecto_adapters_dynamodb/query.ex
+++ b/lib/ecto_adapters_dynamodb/query.ex
@@ -294,7 +294,7 @@ defmodule Ecto.Adapters.DynamoDB.Query do
 
     case opts[:projection_expression] do
       nil -> [select: opts[:select] || :all_attributes]
-      _ -> Keyword.take(opts, [:projection_expression, :expression_attribute_names])
+      _ -> Keyword.take(opts, [:projection_expression])
     end ++ Keyword.take(opts, take_opts)
   end
 
@@ -454,8 +454,7 @@ defmodule Ecto.Adapters.DynamoDB.Query do
   end
 
   defp construct_batch_get_item_query(table, indexes, hash_values, search, opts) do
-    take_opts =
-      Keyword.take(opts, [:consistent_read, :projection_expression, :expression_attribute_names])
+    take_opts = Keyword.take(opts, [:consistent_read, :projection_expression])
 
     keys =
       case indexes do


### PR DESCRIPTION
This reverts commit 0d5ea67f63df47f15e94d1a88d9b08e65f25e1bc.

Unfortunately, the fix can allow an undefined expression attribute name
to be use in situations where it currently works. So revert it.