### PR TITLE
Fix create_if_not_exists/drop_if_exists for databases with >100 tables

### DIFF
--- a/lib/ecto_adapters_dynamodb/info.ex
+++ b/lib/ecto_adapters_dynamodb/info.ex
@@ -122,6 +122,23 @@ defmodule Ecto.Adapters.DynamoDB.Info do
   end
 
   @doc """
+  Returns a boolean indicating whether or not a given table exists.
+
+  Uses `DescribeTable` instead of `ListTables` to check table existence.
+  `ListTables` returns a maximum of 100 table names per request and doesn't
+  implement pagination, so tables beyond the first 100 won't be found.
+
+  See: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html
+  """
+  @spec table_exists?(Repo.t(), String.t()) :: boolean()
+  def table_exists?(repo, table_name) do
+    case Dynamo.describe_table(table_name) |> ExAws.request(DynamoDB.ex_aws_config(repo)) do
+      {:ok, _} -> true
+      {:error, _} -> false
+    end
+  end
+
+  @doc """
   returns a list of any indexed attributes in the table
   """
   @spec indexed_attributes(Repo.t(), table_name_t) :: [String.t()]

--- a/lib/ecto_adapters_dynamodb/info.ex
+++ b/lib/ecto_adapters_dynamodb/info.ex
@@ -1,6 +1,6 @@
 defmodule Ecto.Adapters.DynamoDB.Info do
   @moduledoc """
-  Get information on dynamo tables and schema 
+  Get information on dynamo tables and schema
   """
 
   alias Ecto.Adapters.DynamoDB
@@ -134,7 +134,7 @@ defmodule Ecto.Adapters.DynamoDB.Info do
   def table_exists?(repo, table_name) do
     case Dynamo.describe_table(table_name) |> ExAws.request(DynamoDB.ex_aws_config(repo)) do
       {:ok, _} -> true
-      {:error, _} -> false
+      {:error, _error_tuple} -> false
     end
   end
 
@@ -165,7 +165,7 @@ defmodule Ecto.Adapters.DynamoDB.Info do
       [%{"AttributeName" => fieldname}] ->
         [fieldname]
 
-      # Two entries, it's a HASH + SORT - but they might not be returned in order - So figure out 
+      # Two entries, it's a HASH + SORT - but they might not be returned in order - So figure out
       # which is the hash and which is the sort by matching for the "HASH" attribute in the first,
       # then second element of the list. Match explicitly as we want a crash if we get anything else.
       [

--- a/lib/ecto_adapters_dynamodb/info.ex
+++ b/lib/ecto_adapters_dynamodb/info.ex
@@ -123,12 +123,6 @@ defmodule Ecto.Adapters.DynamoDB.Info do
 
   @doc """
   Returns a boolean indicating whether or not a given table exists.
-
-  Uses `DescribeTable` instead of `ListTables` to check table existence.
-  `ListTables` returns a maximum of 100 table names per request and doesn't
-  implement pagination, so tables beyond the first 100 won't be found.
-
-  See: https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html
   """
   @spec table_exists?(Repo.t(), String.t()) :: boolean()
   def table_exists?(repo, table_name) do

--- a/lib/ecto_adapters_dynamodb/migration.ex
+++ b/lib/ecto_adapters_dynamodb/migration.ex
@@ -2,6 +2,7 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
   import Ecto.Adapters.DynamoDB, only: [ecto_dynamo_log: 2, ecto_dynamo_log: 3, ex_aws_config: 1]
 
   alias ExAws.Dynamo
+  alias Ecto.Adapters.DynamoDB.Info
   alias Ecto.Adapters.DynamoDB.RepoConfig
 
   @moduledoc """
@@ -150,19 +151,9 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
     # :schema_migrations might be provided as an atom, while 'table.name' is now usually a binary
     table_name = if is_atom(table.name), do: Atom.to_string(table.name), else: table.name
 
-    # Use describe_table instead of list_tables to check if table exists.
-    # list_tables returns max 100 tables without pagination, so tables beyond
-    # the first 100 won't be found, causing false "table doesn't exist" results.
-    table_exists =
-      case Dynamo.describe_table(table_name) |> ExAws.request(ex_aws_config(repo)) do
-        {:ok, _} -> true
-        {:error, {"ResourceNotFoundException", _}} -> false
-        {:error, _} -> false
-      end
-
     ecto_dynamo_log(:debug, "#{inspect(__MODULE__)}.execute_ddl: :create_if_not_exists (table)")
 
-    if not table_exists do
+    if not Info.table_exists?(repo, table_name) do
       ecto_dynamo_log(
         :debug,
         "#{inspect(__MODULE__)}.execute_ddl: create_if_not_exist: creating table",
@@ -221,23 +212,14 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
   end
 
   defp execute_ddl(repo, {:drop_if_exists, %Ecto.Migration.Table{} = table, opts}) do
-    # Use describe_table instead of list_tables to check if table exists.
-    # list_tables returns max 100 tables without pagination.
     table_name = if is_atom(table.name), do: Atom.to_string(table.name), else: table.name
-
-    table_exists =
-      case Dynamo.describe_table(table_name) |> ExAws.request(ex_aws_config(repo)) do
-        {:ok, _} -> true
-        {:error, {"ResourceNotFoundException", _}} -> false
-        {:error, _} -> false
-      end
 
     ecto_dynamo_log(
       :debug,
       "#{inspect(__MODULE__)}.execute_ddl: drop_if_exists (table) opts (ignored): #{inspect(opts)}"
     )
 
-    if table_exists do
+    if Info.table_exists?(repo, table_name) do
       ecto_dynamo_log(
         :debug,
         "#{inspect(__MODULE__)}.execute_ddl: drop_if_exists: removing table",

--- a/lib/ecto_adapters_dynamodb/migration.ex
+++ b/lib/ecto_adapters_dynamodb/migration.ex
@@ -149,11 +149,20 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
   defp execute_ddl(repo, {:create_if_not_exists, %Ecto.Migration.Table{} = table, field_clauses}) do
     # :schema_migrations might be provided as an atom, while 'table.name' is now usually a binary
     table_name = if is_atom(table.name), do: Atom.to_string(table.name), else: table.name
-    %{"TableNames" => table_list} = Dynamo.list_tables() |> ExAws.request!(ex_aws_config(repo))
+
+    # Use describe_table instead of list_tables to check if table exists.
+    # list_tables returns max 100 tables without pagination, so tables beyond
+    # the first 100 won't be found, causing false "table doesn't exist" results.
+    table_exists =
+      case Dynamo.describe_table(table_name) |> ExAws.request(ex_aws_config(repo)) do
+        {:ok, _} -> true
+        {:error, {"ResourceNotFoundException", _}} -> false
+        {:error, _} -> false
+      end
 
     ecto_dynamo_log(:debug, "#{inspect(__MODULE__)}.execute_ddl: :create_if_not_exists (table)")
 
-    if not Enum.member?(table_list, table_name) do
+    if not table_exists do
       ecto_dynamo_log(
         :debug,
         "#{inspect(__MODULE__)}.execute_ddl: create_if_not_exist: creating table",
@@ -212,14 +221,23 @@ defmodule Ecto.Adapters.DynamoDB.Migration do
   end
 
   defp execute_ddl(repo, {:drop_if_exists, %Ecto.Migration.Table{} = table, opts}) do
-    %{"TableNames" => table_list} = Dynamo.list_tables() |> ExAws.request!(ex_aws_config(repo))
+    # Use describe_table instead of list_tables to check if table exists.
+    # list_tables returns max 100 tables without pagination.
+    table_name = if is_atom(table.name), do: Atom.to_string(table.name), else: table.name
+
+    table_exists =
+      case Dynamo.describe_table(table_name) |> ExAws.request(ex_aws_config(repo)) do
+        {:ok, _} -> true
+        {:error, {"ResourceNotFoundException", _}} -> false
+        {:error, _} -> false
+      end
 
     ecto_dynamo_log(
       :debug,
       "#{inspect(__MODULE__)}.execute_ddl: drop_if_exists (table) opts (ignored): #{inspect(opts)}"
     )
 
-    if Enum.member?(table_list, table.name) do
+    if table_exists do
       ecto_dynamo_log(
         :debug,
         "#{inspect(__MODULE__)}.execute_ddl: drop_if_exists: removing table",

--- a/test/ecto_adapters_dynamodb/info_test.exs
+++ b/test/ecto_adapters_dynamodb/info_test.exs
@@ -194,6 +194,16 @@ defmodule Ecto.Adapters.DynamoDB.Info.Test do
     assert indexed_attributes(TestRepo, "test_planet") == ["id", "name", "mass"]
   end
 
+  describe "table_exists?" do
+    test "returns true for existing table" do
+      assert table_exists?(TestRepo, "test_person") == true
+    end
+
+    test "returns false for non-existing table" do
+      assert table_exists?(TestRepo, "non_existing_table_12345") == false
+    end
+  end
+
   defp normalise_info(info) when is_map(info) do
     info
     |> Enum.map(fn {k, v} -> {k, normalise_info(v)} end)


### PR DESCRIPTION
## Problem

`list_tables()` returns a maximum of 100 tables per request ([DynamoDB API limit](https://docs.aws.amazon.com/amazondynamodb/latest/APIReference/API_ListTables.html)). The adapter doesn't implement pagination, so tables beyond the first 100 are never found.

This causes `create_if_not_exists` to incorrectly attempt creating tables that already exist, resulting in:

```elixir
ExAws Request Error! {"ResourceInUseException", "Table already exists"}
```

## Solution

Replace `list_tables()` with `describe_table()` to check if a specific table exists.

Added `Ecto.Adapters.DynamoDB.Info.table_exists?/2` - a public function that can be used to check table existence.

Benefits:
- No pagination needed - checks single table directly
- More efficient - one targeted request vs fetching all table names
- Works regardless of total table count

## Testing

All existing tests pass + 2 new tests for `table_exists?/2` (87 tests, 0 failures).
