### PR TITLE
Handle error function clause error

### DIFF
--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -1741,8 +1741,8 @@ defmodule Ecto.Adapters.DynamoDB do
           Enum.any?(record, fn {field, val} ->
             [type] = Dynamo.Encoder.encode(val) |> Map.keys()
 
-            # Ecto does not convert Empty strings to nil before passing them to Repo.update_all or
-            # Repo.insert_all DynamoDB provides an instructive message during an update (forwarded by ExAws),
+            # Ecto does not convert empty strings to nil before passing them to Repo.update_all or
+            # Repo.insert_all. DynamoDB provides an instructive message during an update (forwarded by ExAws),
             # but less so for batch_write_item, so we catch the empty string as well.
             # Dynamo does not allow insertion of empty strings in any case.
             (Enum.member?(indexed_fields, to_string(field)) and type not in ["S", "N"]) ||
@@ -1761,6 +1761,12 @@ defmodule Ecto.Adapters.DynamoDB do
       true ->
         raise ExAws.Error, message: "ExAws Request Error! #{inspect(error)}"
     end
+  end
+
+  # Maybe more rarely seen, the tuple in the first argument may also have three elements, such as
+  # {:error, {:http_error, 500, "{\"__type\":\"com.amazonaws.dynamodb.v20120810#InternalServerError\",\"message\":\"Internal server error\"}"}}
+  defp handle_error!({:error, {_error_type, _status, _info} = error}, _repo, _params) do
+    raise ExAws.Error, message: "ExAws Request Error! #{inspect(error)}"
   end
 
   @doc """

--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -1752,9 +1752,6 @@ defmodule Ecto.Adapters.DynamoDB do
 
     cond do
       # we use this error to check if an update or delete record does not exist
-
-      # FIXME - should the second value be "TransactionCanceledException"? Maybe some possible refactor with the other error handler below if so.
-      # Also see other use cases of that value in this file.
       error_name in ["ConditionalCheckFailedException", "TransactionConflictException"] ->
         {:error, error_name}
 
@@ -1766,15 +1763,14 @@ defmodule Ecto.Adapters.DynamoDB do
     end
   end
 
-  # In the case of 5XX errors, a three-element error tuple will be returned; this may also happen when the error_name
-  # is "TransactionCanceledException" or "ConditionalCheckFailedException" (the latter would only occur if
-  # return_values_on_condition_check_failure was set to :all_old, which is not the case at the moment).
-  defp handle_error!({:error, {error_name, _, _} = error}, _repo, _params) do
-    if error_name == :http_error do
-      raise ExAws.Error, message: "ExAws Request Error! #{inspect(error)}"
-    else
-      {:error, error_name}
-    end
+  # There are a few cases in which the second element of the :error tuple is a three-element tuple:
+  # - For 5XX errors (rare!), an :http_error tuple will be returned from ExAws.Request.
+  # - When error_name is "TransactionCanceledException" as returned by ExAws.Dynamo - not currently handled here,
+  #   as we do not use any of the Transact methods.
+  # - When error_name is "ConditionalCheckFailedException" and return_values_on_condition_check_failure option is
+  #   set to :all_old as returned by ExAws.Dynamo - also not currently handled here, as we do not use the :all_old option.
+  defp handle_error!({:error, {:http_error, _, _} = error}, _repo, _params) do
+    raise ExAws.Error, message: "ExAws Request Error! #{inspect(error)}"
   end
 
   @doc """

--- a/lib/ecto_adapters_dynamodb.ex
+++ b/lib/ecto_adapters_dynamodb.ex
@@ -1752,6 +1752,9 @@ defmodule Ecto.Adapters.DynamoDB do
 
     cond do
       # we use this error to check if an update or delete record does not exist
+
+      # FIXME - should the second value be "TransactionCanceledException"? Maybe some possible refactor with the other error handler below if so.
+      # Also see other use cases of that value in this file.
       error_name in ["ConditionalCheckFailedException", "TransactionConflictException"] ->
         {:error, error_name}
 
@@ -1763,10 +1766,15 @@ defmodule Ecto.Adapters.DynamoDB do
     end
   end
 
-  # Maybe more rarely seen, the tuple in the first argument may also have three elements, such as
-  # {:error, {:http_error, 500, "{\"__type\":\"com.amazonaws.dynamodb.v20120810#InternalServerError\",\"message\":\"Internal server error\"}"}}
-  defp handle_error!({:error, {_error_type, _status, _info} = error}, _repo, _params) do
-    raise ExAws.Error, message: "ExAws Request Error! #{inspect(error)}"
+  # In the case of 5XX errors, a three-element error tuple will be returned; this may also happen when the error_name
+  # is "TransactionCanceledException" or "ConditionalCheckFailedException" (the latter would only occur if
+  # return_values_on_condition_check_failure was set to :all_old, which is not the case at the moment).
+  defp handle_error!({:error, {error_name, _, _} = error}, _repo, _params) do
+    if error_name == :http_error do
+      raise ExAws.Error, message: "ExAws Request Error! #{inspect(error)}"
+    else
+      {:error, error_name}
+    end
   end
 
   @doc """

--- a/mix.exs
+++ b/mix.exs
@@ -18,8 +18,13 @@ defmodule Ecto.Adapters.DynamoDB.Mixfile do
       description:
         "A DynamoDB adapter for Ecto supporting basic queries. See https://github.com/circles-learning-labs/ecto_adapters_dynamodb for detailed instructions.",
       package: package(),
-      source_url: "https://github.com/circles-learning-labs/ecto_adapters_dynamodb",
-      preferred_cli_env: [
+      source_url: "https://github.com/circles-learning-labs/ecto_adapters_dynamodb"
+    ]
+  end
+
+  def cli do
+    [
+      preferred_envs: [
         coveralls: :test,
         "coveralls.detail": :test,
         "coveralls.post": :test,

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -1189,6 +1189,56 @@ defmodule Ecto.Adapters.DynamoDB.Test do
     end
   end
 
+  describe "http_error (5XX) handling" do
+    setup do
+      fruit = TestRepo.insert!(%Fruit{name: "fruit"})
+
+      {:ok, fruit: fruit}
+    end
+
+    test_with_mock "update raises ExAws.Error",
+                   %{fruit: fruit},
+                   ExAws,
+                   [:passthrough],
+                   http_error_mock() do
+      assert_raise ExAws.Error, ~r/http_error/, fn ->
+        fruit
+        |> Fruit.changeset(%{name: "banana"})
+        |> TestRepo.update!()
+      end
+
+      assert_called_exactly(ExAws.request(:_, :_), 1)
+    end
+
+    test_with_mock "insert raises ExAws.Error", ExAws, [:passthrough], http_error_mock() do
+      assert_raise ExAws.Error, ~r/http_error/, fn ->
+        TestRepo.insert!(%Fruit{name: "Orange"})
+      end
+    end
+
+    test_with_mock "delete raises ExAws.Error",
+                   %{fruit: fruit},
+                   ExAws,
+                   [:passthrough],
+                   http_error_mock() do
+      assert_raise ExAws.Error, ~r/http_error/, fn ->
+        TestRepo.delete!(fruit)
+      end
+    end
+
+    defp http_error_mock do
+      # A real-life example of what the error body may look like in cases of a 500 error.
+      http_error_body =
+        ~s({"__type":"com.amazonaws.dynamodb.v20120810#InternalServerError","message":"Internal server error"})
+
+      [
+        request: fn _request, _config ->
+          {:error, {:http_error, 500, http_error_body}}
+        end
+      ]
+    end
+  end
+
   describe "decimal type handling" do
     test "insert and retrieve decimal fields" do
       {:ok, product} =

--- a/test/ecto_adapters_dynamodb_test.exs
+++ b/test/ecto_adapters_dynamodb_test.exs
@@ -1190,6 +1190,9 @@ defmodule Ecto.Adapters.DynamoDB.Test do
   end
 
   describe "http_error (5XX) handling" do
+    # A real-life example of what the error body may look like in cases of a 500 error.
+    @http_error_body ~s({"__type":"com.amazonaws.dynamodb.v20120810#InternalServerError","message":"Internal server error"})
+
     setup do
       fruit = TestRepo.insert!(%Fruit{name: "fruit"})
 
@@ -1201,39 +1204,21 @@ defmodule Ecto.Adapters.DynamoDB.Test do
                    ExAws,
                    [:passthrough],
                    http_error_mock() do
-      assert_raise ExAws.Error, ~r/http_error/, fn ->
-        fruit
-        |> Fruit.changeset(%{name: "banana"})
-        |> TestRepo.update!()
-      end
+      assert_raise ExAws.Error,
+                   "ExAws Request Error! #{inspect({:http_error, 500, @http_error_body})}",
+                   fn ->
+                     fruit
+                     |> Fruit.changeset(%{name: "banana"})
+                     |> TestRepo.update!()
+                   end
 
       assert_called_exactly(ExAws.request(:_, :_), 1)
     end
 
-    test_with_mock "insert raises ExAws.Error", ExAws, [:passthrough], http_error_mock() do
-      assert_raise ExAws.Error, ~r/http_error/, fn ->
-        TestRepo.insert!(%Fruit{name: "Orange"})
-      end
-    end
-
-    test_with_mock "delete raises ExAws.Error",
-                   %{fruit: fruit},
-                   ExAws,
-                   [:passthrough],
-                   http_error_mock() do
-      assert_raise ExAws.Error, ~r/http_error/, fn ->
-        TestRepo.delete!(fruit)
-      end
-    end
-
     defp http_error_mock do
-      # A real-life example of what the error body may look like in cases of a 500 error.
-      http_error_body =
-        ~s({"__type":"com.amazonaws.dynamodb.v20120810#InternalServerError","message":"Internal server error"})
-
       [
         request: fn _request, _config ->
-          {:error, {:http_error, 500, http_error_body}}
+          {:error, {:http_error, 500, @http_error_body}}
         end
       ]
     end


### PR DESCRIPTION
This PR address the function clause error described in https://app.shortcut.com/circles-dev/story/20987/handle-error-3-function-clause-error, where 500 errors were returning a three-element tuple as the first argument that did not match on the existing definitions of `handle_error!/3`.

In `ExAws.Request`, there are several cases where a tuple shaped like `{:error, {:http_error, status, body}}` may be returned, including in the case of 500 errors, which we encountered recently with DynamoDB - this caused a function clause error:

```
no function clause matching in Ecto.Adapters.DynamoDB.handle_error!/3

The following arguments were given to Ecto.Adapters.DynamoDB.handle_error!/3:

    # 1
    {:error, {:http_error, 500, "{\"__type\":\"com.amazonaws.dynamodb.v20120810#InternalServerError\",\"message\":\"Internal server error\"}"}}

    # 2
    Repo

    # 3
    %{table: "some_table", records: [%{updated_at: "2026-06-05T22:21:57.017370Z"}]}
```

There are also two other possible code paths through the ExAws.Dynamo dependency that could result in these three-element tuples, but they are not currently used by this adapter - however, I have noted those cases in the code for potential use by future developers.